### PR TITLE
RustSec Interoperability

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ chrono = { version = "0.4", features = ["serde"] }
 cvss = { version = "1.x", features = ["serde"] }
 rustsec = "0.24"
 crates-index = "0.17"
+serde_with = "1.11"
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ url = { version = "2.x", features = ["serde"] }
 chrono = { version = "0.4", features = ["serde"] }
 cvss = { version = "1.x", features = ["serde"] }
 rustsec = "0.24"
+crates-index = "0.17"
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ serde = { version = "1.0", features = ["derive"] }
 url = { version = "2.x", features = ["serde"] }
 chrono = { version = "0.4", features = ["serde"] }
 cvss = { version = "1.x", features = ["serde"] }
+rustsec = "0.24"
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/src/definitions.rs
+++ b/src/definitions.rs
@@ -5,6 +5,7 @@ use url::Url;
 pub(crate) type AcknowledgmentsT = Vec<Acknowledgment>;
 
 // TODO: with at least 1 and at most 4 properties
+#[serde_with::skip_serializing_none]
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Acknowledgment {
     pub names: Option<Vec<String>>,
@@ -16,6 +17,7 @@ pub struct Acknowledgment {
 // https://github.com/oasis-tcs/csaf/blob/master/csaf_2.0/prose/csaf-v2-editor-draft.md#312-branches-type
 pub(crate) type BranchesT = Vec<Branch>;
 
+#[serde_with::skip_serializing_none]
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Branch {
     pub name: String,
@@ -42,6 +44,7 @@ pub enum BranchCategory {
 }
 
 // https://github.com/oasis-tcs/csaf/blob/master/csaf_2.0/prose/csaf-v2-editor-draft.md#313-full-product-name-type
+#[serde_with::skip_serializing_none]
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct FullProductName {
     pub name: String,
@@ -50,6 +53,7 @@ pub struct FullProductName {
 }
 
 // https://github.com/oasis-tcs/csaf/blob/master/csaf_2.0/prose/csaf-v2-editor-draft.md#3133-full-product-name-type---product-identification-helper
+#[serde_with::skip_serializing_none]
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct ProductIdentificationHelper {
     pub cpe: Option<String>, // TODO: Integrate actual CPE aware data type
@@ -79,6 +83,7 @@ pub(crate) type LangT = String; // TODO: Constrain/validate
 // https://github.com/oasis-tcs/csaf/blob/master/csaf_2.0/prose/csaf-v2-editor-draft.md#315-notes-type
 pub(crate) type NotesT = Vec<Note>;
 
+#[serde_with::skip_serializing_none]
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Note {
     pub category: NoteCategory,
@@ -115,6 +120,7 @@ pub(crate) type ProductsT = Vec<ProductIdT>;
 // https://github.com/oasis-tcs/csaf/blob/master/csaf_2.0/prose/csaf-v2-editor-draft.md#3110-references-type
 pub(crate) type ReferencesT = Vec<Reference>;
 
+#[serde_with::skip_serializing_none]
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Reference {
     pub url: Url,

--- a/src/definitions.rs
+++ b/src/definitions.rs
@@ -16,7 +16,7 @@ pub struct Acknowledgment {
 // https://github.com/oasis-tcs/csaf/blob/master/csaf_2.0/prose/csaf-v2-editor-draft.md#312-branches-type
 pub(crate) type BranchesT = Vec<Branch>;
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Branch {
     pub name: String,
     pub category: BranchCategory,
@@ -25,7 +25,7 @@ pub struct Branch {
     pub branches: Option<BranchesT>,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "snake_case")]
 pub enum BranchCategory {
     Architecture,
@@ -42,7 +42,7 @@ pub enum BranchCategory {
 }
 
 // https://github.com/oasis-tcs/csaf/blob/master/csaf_2.0/prose/csaf-v2-editor-draft.md#313-full-product-name-type
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct FullProductName {
     pub name: String,
     pub product_id: ProductIdT,
@@ -50,7 +50,7 @@ pub struct FullProductName {
 }
 
 // https://github.com/oasis-tcs/csaf/blob/master/csaf_2.0/prose/csaf-v2-editor-draft.md#3133-full-product-name-type---product-identification-helper
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct ProductIdentificationHelper {
     pub cpe: Option<String>, // TODO: Integrate actual CPE aware data type
     pub hashes: Option<Vec<HashCollection>>,
@@ -61,13 +61,13 @@ pub struct ProductIdentificationHelper {
     pub x_generic_uris: Option<Vec<Url>>,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct HashCollection {
     pub file_hashes: Vec<HashValue>,
     pub file_name: String,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct HashValue {
     pub algorithm: String,
     pub value: String,
@@ -106,7 +106,8 @@ pub(crate) type ProductGroupIdT = String;
 pub(crate) type ProductGroupsT = Vec<ProductGroupIdT>;
 
 // https://github.com/oasis-tcs/csaf/blob/master/csaf_2.0/prose/csaf-v2-editor-draft.md#318-product-id-type
-pub(crate) type ProductIdT = String;
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct ProductIdT(pub(crate) String);
 
 // https://github.com/oasis-tcs/csaf/blob/master/csaf_2.0/prose/csaf-v2-editor-draft.md#319-products-type
 pub(crate) type ProductsT = Vec<ProductIdT>;

--- a/src/document.rs
+++ b/src/document.rs
@@ -5,6 +5,7 @@ use url::Url;
 use crate::definitions::{AcknowledgmentsT, LangT, NotesT, ReferencesT, VersionT};
 
 /// [Document level meta-data](https://github.com/oasis-tcs/csaf/blob/master/csaf_2.0/prose/csaf-v2-editor-draft.md#321-document-property)
+#[serde_with::skip_serializing_none]
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Document {
     pub category: String,
@@ -28,6 +29,7 @@ pub enum CsafVersion {
 }
 
 /// [Publisher property](https://github.com/oasis-tcs/csaf/blob/master/csaf_2.0/prose/csaf-v2-editor-draft.md#3218-document-property---publisher)
+#[serde_with::skip_serializing_none]
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Publisher {
     pub category: PublisherCategory,
@@ -50,6 +52,7 @@ pub enum PublisherCategory {
 }
 
 /// [Tracking metadata](https://github.com/oasis-tcs/csaf/blob/master/csaf_2.0/prose/csaf-v2-editor-draft.md#32112-document-property---tracking)
+#[serde_with::skip_serializing_none]
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Tracking {
     pub current_release_date: DateTime<Utc>,
@@ -63,12 +66,14 @@ pub struct Tracking {
 }
 
 /// [Document Generator](https://github.com/oasis-tcs/csaf/blob/master/csaf_2.0/prose/csaf-v2-editor-draft.md#321123-document-property---tracking---generator)
+#[serde_with::skip_serializing_none]
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Generator {
     pub engine: Engine,
     pub date: Option<DateTime<Utc>>,
 }
 
+#[serde_with::skip_serializing_none]
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Engine {
     pub name: String,
@@ -107,6 +112,7 @@ pub enum Status {
 }
 
 /// [Aggregate severity](https://github.com/oasis-tcs/csaf/blob/master/csaf_2.0/prose/csaf-v2-editor-draft.md#3212-document-property---aggregate-severity)
+#[serde_with::skip_serializing_none]
 #[derive(Serialize, Deserialize, Debug)]
 pub struct AggregateSeverity {
     pub text: String,
@@ -114,6 +120,7 @@ pub struct AggregateSeverity {
 }
 
 /// [Distribution](https://github.com/oasis-tcs/csaf/blob/master/csaf_2.0/prose/csaf-v2-editor-draft.md#3215-document-property---distribution)
+#[serde_with::skip_serializing_none]
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Distribution {
     // TODO: enforce 'with at least 1 of the 2 properties'
@@ -122,6 +129,7 @@ pub struct Distribution {
 }
 
 /// [TLP](https://github.com/oasis-tcs/csaf/blob/master/csaf_2.0/prose/csaf-v2-editor-draft.md#32152-document-property---distribution---tlp)
+#[serde_with::skip_serializing_none]
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Tlp {
     pub label: TlpLabel,

--- a/src/interop.rs
+++ b/src/interop.rs
@@ -1,0 +1,138 @@
+use std::convert::TryInto;
+
+use crate::{
+    definitions::{FullProductName, Reference},
+    document::{
+        CsafVersion, Document, Generator, Publisher, PublisherCategory, Revision, Status, Tracking,
+    },
+    product_tree::ProductTree,
+    vulnerability::{Vulnerability, VulnerabilityId},
+    Csaf,
+};
+use chrono::{TimeZone, Utc};
+use rustsec::Advisory;
+use url::Url;
+
+const PRODUCT_ID: &str = "PID-1";
+
+// ASSUMPTIONS:
+// There is no 'history' in RUSTSEC advisories, so current advisory IS initial advisory
+// TODO: Should insert two revisions in the case where withdrawn in set
+//
+// Each RUSTSEC advisory applies to only one 'product' - in this case crate, thus can be referred to
+// by one product_id, which must only be unique with the document.
+
+impl From<Advisory> for Csaf {
+    fn from(input: Advisory) -> Self {
+        let advisory_date = input.metadata.date;
+        let advisory_date = Utc
+            .ymd(
+                advisory_date.year().try_into().unwrap(),
+                advisory_date.month(),
+                advisory_date.day(),
+            )
+            .and_hms(0, 0, 0);
+
+        Csaf {
+            document: Document {
+                category: "vex".to_string(),
+                publisher: Publisher {
+                    category: PublisherCategory::Coordinator,
+                    name: "RUSTSEC".to_string(),
+                    namespace: Url::parse("https://rustsec.org/").unwrap(),
+                    contact_details: None,
+                    issuing_authority: None,
+                },
+                title: input.metadata.title,
+                tracking: Tracking {
+                    current_release_date: advisory_date,
+                    id: input.metadata.id.to_string(),
+                    initial_release_date: advisory_date,
+                    revision_history: vec![Revision {
+                        date: advisory_date,
+                        number: "1".to_string(),
+                        summary: "RUSTSEC advisory".to_string(),
+                    }],
+                    status: Status::Final,
+                    version: "1".to_string(),
+                    aliases: if input.metadata.aliases.is_empty() {
+                        None
+                    } else {
+                        Some(
+                            input
+                                .metadata
+                                .aliases
+                                .iter()
+                                .map(|id| id.to_string())
+                                .collect(),
+                        )
+                    },
+                    generator: Some(Generator::default()),
+                },
+                csaf_version: CsafVersion::TwoDotZero,
+                acknowledgments: None,
+                aggregate_severity: None,
+                distribution: None,
+                lang: None, // TODO: Understand if RUSTSEC is canonically english
+                notes: None,
+                references: if input.metadata.references.is_empty() {
+                    None
+                } else {
+                    Some(
+                        input
+                            .metadata
+                            .references
+                            .iter()
+                            .map(|url| Reference {
+                                url: url.clone(),
+                                summary: url.to_string(),
+                                category: None,
+                            })
+                            .collect(),
+                    )
+                },
+                source_lang: None,
+            },
+            product_tree: Some(ProductTree {
+                branches: None,
+                full_product_names: Some(vec![FullProductName {
+                    name: input.metadata.package.to_string(),
+                    product_id: PRODUCT_ID.to_string(),
+                    product_identification_helper: None,
+                }]),
+                product_groups: None,
+                relationships: None,
+            }),
+            vulnerabilities: Some(vec![Vulnerability {
+                acknowledgments: None,
+                cve: if input.metadata.id.is_cve() {
+                    Some(input.metadata.id.to_string())
+                } else {
+                    None
+                },
+                cwe: None,
+                discovery_date: None,
+                id: Some(VulnerabilityId {
+                    text: input.metadata.id.to_string(),
+                    system_name: match input.metadata.id.kind() {
+                        rustsec::advisory::id::Kind::RUSTSEC => "RUSTSEC",
+                        rustsec::advisory::id::Kind::CVE => "CVE",
+                        rustsec::advisory::id::Kind::GHSA => "GHSA",
+                        rustsec::advisory::id::Kind::TALOS => "Talos",
+                        _ => "Other",
+                    }
+                    .to_string(),
+                }),
+                involvements: todo!(),
+                notes: todo!(),
+                product_status: todo!(),
+                references: todo!(),
+                release_date: todo!(),
+                remediations: todo!(),
+                scores: todo!(),
+                threats: todo!(),
+                title: todo!(),
+            }]),
+        }
+    }
+}

--- a/src/interop.rs
+++ b/src/interop.rs
@@ -277,6 +277,7 @@ impl BranchTracking {
         let mut output = Vec::new();
         output.append(&mut self.patched.clone());
         output.append(&mut self.unaffected.clone());
+        output.append(&mut self.vulnerable.clone());
         output
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@ pub mod definitions;
 pub mod interop;
 
 /// [Top level CSAF structure definition](https://github.com/oasis-tcs/csaf/blob/master/csaf_2.0/prose/csaf-v2-editor-draft.md#32-properties)
+#[serde_with::skip_serializing_none]
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Csaf {
     pub document: Document,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,8 @@ use vulnerability::Vulnerability;
 
 pub mod definitions;
 
+pub mod interop;
+
 /// [Top level CSAF structure definition](https://github.com/oasis-tcs/csaf/blob/master/csaf_2.0/prose/csaf-v2-editor-draft.md#32-properties)
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Csaf {

--- a/src/product_tree.rs
+++ b/src/product_tree.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 use crate::definitions::{BranchesT, FullProductName, ProductGroupIdT, ProductIdT};
 
 // https://github.com/oasis-tcs/csaf/blob/master/csaf_2.0/prose/csaf-v2-editor-draft.md#322-product-tree-property
+#[serde_with::skip_serializing_none]
 #[derive(Serialize, Deserialize, Debug)]
 pub struct ProductTree {
     pub branches: Option<BranchesT>,
@@ -11,6 +12,7 @@ pub struct ProductTree {
     pub relationships: Option<Vec<Relationship>>,
 }
 
+#[serde_with::skip_serializing_none]
 #[derive(Serialize, Deserialize, Debug)]
 pub struct ProductGroup {
     pub group_id: ProductGroupIdT,

--- a/src/vulnerability.rs
+++ b/src/vulnerability.rs
@@ -5,6 +5,7 @@ use url::Url;
 use crate::definitions::{AcknowledgmentsT, NotesT, ProductGroupsT, ProductsT, ReferencesT};
 
 // https://github.com/oasis-tcs/csaf/blob/master/csaf_2.0/prose/csaf-v2-editor-draft.md#323-vulnerabilities-property
+#[serde_with::skip_serializing_none]
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Vulnerability {
     pub acknowledgments: Option<AcknowledgmentsT>,
@@ -37,6 +38,7 @@ pub struct VulnerabilityId {
     pub text: String,
 }
 
+#[serde_with::skip_serializing_none]
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Involvement {
     pub party: InvolvementParty,
@@ -67,6 +69,7 @@ pub enum InvolvementStatus {
 }
 
 // https://github.com/oasis-tcs/csaf/blob/master/csaf_2.0/prose/csaf-v2-editor-draft.md#3238-vulnerabilities-property---product-status
+#[serde_with::skip_serializing_none]
 #[derive(Serialize, Deserialize, Debug)]
 pub struct ProductStatus {
     pub first_affected: Option<ProductsT>,
@@ -80,6 +83,7 @@ pub struct ProductStatus {
 }
 
 // https://github.com/oasis-tcs/csaf/blob/master/csaf_2.0/prose/csaf-v2-editor-draft.md#32311-vulnerabilities-property---remediations
+#[serde_with::skip_serializing_none]
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Remediation {
     pub category: RemediationCategory,
@@ -102,6 +106,7 @@ pub enum RemediationCategory {
     Workaround,
 }
 
+#[serde_with::skip_serializing_none]
 #[derive(Serialize, Deserialize, Debug)]
 pub struct RestartRequired {
     pub category: RestartCategory,
@@ -123,6 +128,7 @@ pub enum RestartCategory {
 }
 
 // https://github.com/oasis-tcs/csaf/blob/master/csaf_2.0/prose/csaf-v2-editor-draft.md#32312-vulnerabilities-property---scores
+#[serde_with::skip_serializing_none]
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Score {
     pub products: ProductsT,
@@ -161,6 +167,7 @@ pub enum Cvss3Version {
 }
 
 // https://github.com/oasis-tcs/csaf/blob/master/csaf_2.0/prose/csaf-v2-editor-draft.md#32313-vulnerabilities-property---threats
+#[serde_with::skip_serializing_none]
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Threat {
     pub category: ThreatCategory,

--- a/src/vulnerability.rs
+++ b/src/vulnerability.rs
@@ -1,5 +1,5 @@
 use chrono::{DateTime, Utc};
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, Serializer};
 use url::Url;
 
 use crate::definitions::{AcknowledgmentsT, NotesT, ProductGroupsT, ProductsT, ReferencesT};
@@ -144,7 +144,17 @@ pub struct Cvss3Json {
     pub version: Cvss3Version,
     pub vector_string: cvss::v3::Base,
     pub base_score: f64,
+    #[serde(serialize_with = "severity_to_upper")]
     pub base_severity: cvss::Severity,
+}
+
+// https://www.first.org/cvss/cvss-v3.1.json requires baseSeverity field to be uppercase.
+// cvss crate normalizes to lowercase.
+fn severity_to_upper<S>(severity: &cvss::Severity, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    serializer.serialize_str(&severity.as_str().to_uppercase())
 }
 
 impl From<cvss::v3::Base> for Cvss3Json {

--- a/src/vulnerability.rs
+++ b/src/vulnerability.rs
@@ -131,7 +131,7 @@ pub struct Score {
     pub cvss_v3: Option<Cvss3Json>,
 }
 
-// TODO: Should be able to provide only a `cvss::v3::Base` and have the rest of these populate - proabably a From impl
+// TODO: Should be able to store just the Base and generate the rest of this at serialize time?
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct Cvss3Json {
@@ -139,6 +139,17 @@ pub struct Cvss3Json {
     pub vector_string: cvss::v3::Base,
     pub base_score: f64,
     pub base_severity: cvss::Severity,
+}
+
+impl From<cvss::v3::Base> for Cvss3Json {
+    fn from(b: cvss::v3::Base) -> Self {
+        Self {
+            version: Cvss3Version::ThreeDotOne,
+            vector_string: b.clone(),
+            base_score: b.score().value(),
+            base_severity: b.severity(),
+        }
+    }
 }
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/tests/RUSTSEC-2021-0093.md
+++ b/tests/RUSTSEC-2021-0093.md
@@ -1,0 +1,21 @@
+```toml
+[advisory]
+id = "RUSTSEC-2021-0093"
+package = "crossbeam-deque"
+aliases = ["GHSA-pqqp-xmhj-wgcw", "CVE-2021-32810"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+categories = ["memory-corruption"]
+date = "2021-07-30"
+url = "https://github.com/crossbeam-rs/crossbeam/security/advisories/GHSA-pqqp-xmhj-wgcw"
+
+[versions]
+patched = [">= 0.7.4, < 0.8.0", ">= 0.8.1"]
+```
+
+# Data race in crossbeam-deque
+
+In the affected version of this crate, the result of the race condition is that one or more tasks in the worker queue can be popped twice instead of other tasks that are forgotten and never popped. If tasks are allocated on the heap, this can cause double free and a memory leak. If not, this still can cause a logical bug.
+
+Crates using `Stealer::steal`, `Stealer::steal_batch`, or `Stealer::steal_batch_and_pop` are affected by this issue.
+
+Credits to @kmaork for discovering, reporting and fixing the bug.


### PR DESCRIPTION
Lands lightly validated support for [`rustsec::Advisory`](https://docs.rs/rustsec/0.24.3/rustsec/advisory/struct.Advisory.html) conversion to a `Csaf` object, which can be serialized in to valid CSAF json. Targets the [`VEX`](https://github.com/oasis-tcs/csaf/blob/master/csaf_2.0/prose/csaf-v2-editor-draft.md#45-profile-5-vex) profile. Passes CSAF validation but misses at least one `VEX` requirement - does not provide an impact statement for all `known_not_affected` versions as RustSec has no representation of that upstream.