### PR TITLE
workaround for missing cvss v2 section

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 Cargo.lock
 .vscode
+.idea/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ chrono = { version = "0.4", features = ["serde"] }
 cvss = { version = "2", features = ["serde"] }
 rustsec = { version = "0.26", optional = true }
 # Has to be kept in sync with version used by rustsec
-crates-index = { version = "0.18", optional = true }
+crates-index = { version = "0.19", optional = true }
 serde_with = "2"
 packageurl = "0.3"
 cpe = "0.1.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,8 @@ cvss = { version = "2", features = ["serde"] }
 rustsec = { version = "0.26", optional = true }
 # Has to be kept in sync with version used by rustsec
 crates-index = { version = "0.19", optional = true }
-serde_with = "2"
+serde_json = "1"
+serde_with = "3"
 packageurl = "0.3"
 cpe = "0.1.2"
 

--- a/src/vulnerability.rs
+++ b/src/vulnerability.rs
@@ -166,7 +166,7 @@ pub struct Score {
     pub products: ProductsT,
     // TODO: A CVSS v2 representation, or just document it as out of scope
     // TODO: Should have at least one of:
-    pub cvss_v2: Option<String>,
+    pub cvss_v2: Option<serde_json::Value>,
     #[serde_as(as = "Option<FromInto<cvss_json::Cvss3>>")]
     pub cvss_v3: Option<cvss::v3::Base>,
 }


### PR DESCRIPTION
This PR includes #9 to fix the build.

---


fix: represent the CVSS v2 section as "any JSON"

The current definition of "string" doesn't work out. I understand that there currently is no v2 definition available, however if a v2 section is present, now it will fail to parse the file as a "string" is expected but a "map" is found.