### PR TITLE
SVG badges should link to relevant page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 ## Common Security Advisory Framework (CSAF)
 
-![Crates.io](https://img.shields.io/crates/v/csaf)
-![Crates.io](https://img.shields.io/crates/l/csaf)
-![docs.rs](https://img.shields.io/docsrs/csaf)
-![GitHub branch checks state](https://img.shields.io/github/checks-status/voteblake/csaf-rs/main)
+[![Crates.io](https://img.shields.io/crates/v/csaf)](https://crates.io/crates/csaf)
+[![Crates.io](https://img.shields.io/crates/l/csaf)](https://crates.io/crates/csaf)
+[![docs.rs](https://img.shields.io/docsrs/csaf)](https://docs.rs/csaf/)
+[![GitHub branch checks state](https://img.shields.io/github/checks-status/voteblake/csaf-rs/main)](https://github.com/voteblake/csaf-rs/actions)
 
 A lovingly hand-crafted<sup>[1](#footnote1)</sup> implementation of [CSAF](https://www.oasis-open.org/committees/tc_home.php?wg_abbrev=csaf) for Rust. Currently, based on the [v2.0 editor draft](https://github.com/oasis-tcs/csaf/blob/master/csaf_2.0/prose/csaf-v2-editor-draft.md). Should be considered strictly less-strict than the spec right now - valid CSAF should deserialize successfully, but invalid CSAF may also succeed and the library may generate invalid CSAF.
 


### PR DESCRIPTION
README badges are more helpful if you can follow them as links to the relevant page.