### PR TITLE
Derive Clone and PartialEq for Csaf Root Type

### DIFF
--- a/src/definitions.rs
+++ b/src/definitions.rs
@@ -10,7 +10,7 @@ pub(crate) type AcknowledgmentsT = Vec<Acknowledgment>;
 // TODO: with at least 1 and at most 4 properties
 /// [Acknowledgment](https://github.com/oasis-tcs/csaf/blob/master/csaf_2.0/prose/csaf-v2-editor-draft.md#311-acknowledgments-type)
 #[serde_with::skip_serializing_none]
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct Acknowledgment {
     pub names: Option<Vec<String>>,
     pub organization: Option<String>,
@@ -19,7 +19,7 @@ pub struct Acknowledgment {
 }
 
 /// [Branches](https://github.com/oasis-tcs/csaf/blob/master/csaf_2.0/prose/csaf-v2-editor-draft.md#312-branches-type)
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct BranchesT(pub Vec<Branch>);
 
 impl BranchesT {
@@ -45,7 +45,7 @@ impl TryFrom<&Branch> for ProductIdT {
 
 /// [Branch](https://github.com/oasis-tcs/csaf/blob/master/csaf_2.0/prose/csaf-v2-editor-draft.md#3121-branches-type---branches)
 #[serde_with::skip_serializing_none]
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct Branch {
     pub name: String,
     pub category: BranchCategory,
@@ -55,7 +55,7 @@ pub struct Branch {
 }
 
 /// [Branch Category](https://github.com/oasis-tcs/csaf/blob/master/csaf_2.0/prose/csaf-v2-editor-draft.md#3122-branches-type---category)
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub enum BranchCategory {
     Architecture,
@@ -74,7 +74,7 @@ pub enum BranchCategory {
 
 /// [Full Product Name](https://github.com/oasis-tcs/csaf/blob/master/csaf_2.0/prose/csaf-v2-editor-draft.md#313-full-product-name-type)
 #[serde_with::skip_serializing_none]
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct FullProductName {
     pub name: String,
     pub product_id: ProductIdT,
@@ -84,7 +84,7 @@ pub struct FullProductName {
 /// [Product Identification Helper](https://github.com/oasis-tcs/csaf/blob/master/csaf_2.0/prose/csaf-v2-editor-draft.md#3133-full-product-name-type---product-identification-helper)
 #[serde_as]
 #[serde_with::skip_serializing_none]
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct ProductIdentificationHelper {
     #[serde_as(as = "Option<DisplayFromStr>")]
     pub cpe: Option<cpe::uri::OwnedUri>,
@@ -99,14 +99,14 @@ pub struct ProductIdentificationHelper {
 }
 
 /// [Hashes](https://github.com/oasis-tcs/csaf/blob/master/csaf_2.0/prose/csaf-v2-editor-draft.md#31332-full-product-name-type---product-identification-helper---hashes)
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct HashCollection {
     pub file_hashes: Vec<HashValue>,
     pub file_name: String,
 }
 
 /// [Hashes](https://github.com/oasis-tcs/csaf/blob/master/csaf_2.0/prose/csaf-v2-editor-draft.md#31332-full-product-name-type---product-identification-helper---hashes)
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct HashValue {
     // TODO: Validation - These values are derived from the currently supported digests OpenSSL [OPENSSL]. Leading dashs were removed.
     pub algorithm: String,
@@ -121,7 +121,7 @@ pub(crate) type NotesT = Vec<Note>;
 
 /// [Notes](https://github.com/oasis-tcs/csaf/blob/master/csaf_2.0/prose/csaf-v2-editor-draft.md#315-notes-type)
 #[serde_with::skip_serializing_none]
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct Note {
     pub category: NoteCategory,
     pub text: String,
@@ -130,7 +130,7 @@ pub struct Note {
 }
 
 /// [Notes](https://github.com/oasis-tcs/csaf/blob/master/csaf_2.0/prose/csaf-v2-editor-draft.md#315-notes-type)
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub enum NoteCategory {
     Description,
@@ -149,7 +149,7 @@ pub(crate) type ProductGroupIdT = String;
 pub(crate) type ProductGroupsT = Vec<ProductGroupIdT>;
 
 /// [Product IDs](https://github.com/oasis-tcs/csaf/blob/master/csaf_2.0/prose/csaf-v2-editor-draft.md#318-product-id-type)
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct ProductIdT(pub String);
 
 /// [Products](https://github.com/oasis-tcs/csaf/blob/master/csaf_2.0/prose/csaf-v2-editor-draft.md#319-products-type)
@@ -159,7 +159,7 @@ pub(crate) type ReferencesT = Vec<Reference>;
 
 /// [References](https://github.com/oasis-tcs/csaf/blob/master/csaf_2.0/prose/csaf-v2-editor-draft.md#3110-references-type)
 #[serde_with::skip_serializing_none]
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct Reference {
     pub url: Url,
     pub summary: String,
@@ -167,7 +167,7 @@ pub struct Reference {
 }
 
 /// [References](https://github.com/oasis-tcs/csaf/blob/master/csaf_2.0/prose/csaf-v2-editor-draft.md#3110-references-type)
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub enum ReferenceCategory {
     External,

--- a/src/document.rs
+++ b/src/document.rs
@@ -10,7 +10,7 @@ use crate::definitions::{AcknowledgmentsT, LangT, NotesT, ReferencesT, VersionT}
 /// [Document level meta-data](https://github.com/oasis-tcs/csaf/blob/master/csaf_2.0/prose/csaf-v2-editor-draft.md#321-document-property)
 #[serde_as]
 #[serde_with::skip_serializing_none]
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct Document {
     /// [See Category specification](https://github.com/oasis-tcs/csaf/blob/master/csaf_2.0/prose/csaf-v2-editor-draft.md#3213-document-property---category)
     #[serde_as(as = "DisplayFromStr")]
@@ -28,7 +28,7 @@ pub struct Document {
     pub source_lang: Option<LangT>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum Category {
     Base,
     SecurityAdvisory,
@@ -65,7 +65,7 @@ impl Display for Category {
 }
 
 /// [CSAF Version](https://github.com/oasis-tcs/csaf/blob/master/csaf_2.0/prose/csaf-v2-editor-draft.md#3214-document-property---csaf-version)
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub enum CsafVersion {
     #[serde(rename = "2.0")]
     TwoDotZero,
@@ -73,7 +73,7 @@ pub enum CsafVersion {
 
 /// [Publisher property](https://github.com/oasis-tcs/csaf/blob/master/csaf_2.0/prose/csaf-v2-editor-draft.md#3218-document-property---publisher)
 #[serde_with::skip_serializing_none]
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct Publisher {
     pub category: PublisherCategory,
     pub name: String,
@@ -83,7 +83,7 @@ pub struct Publisher {
 }
 
 /// [Publisher category](https://github.com/oasis-tcs/csaf/blob/master/csaf_2.0/prose/csaf-v2-editor-draft.md#32181-document-property---publisher---category)
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[serde(rename_all = "lowercase")]
 pub enum PublisherCategory {
     Coordinator,
@@ -96,7 +96,7 @@ pub enum PublisherCategory {
 
 /// [Tracking metadata](https://github.com/oasis-tcs/csaf/blob/master/csaf_2.0/prose/csaf-v2-editor-draft.md#32112-document-property---tracking)
 #[serde_with::skip_serializing_none]
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct Tracking {
     pub current_release_date: DateTime<Utc>,
     pub id: String,
@@ -110,7 +110,7 @@ pub struct Tracking {
 
 /// [Document Generator](https://github.com/oasis-tcs/csaf/blob/master/csaf_2.0/prose/csaf-v2-editor-draft.md#321123-document-property---tracking---generator)
 #[serde_with::skip_serializing_none]
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct Generator {
     pub engine: Engine,
     pub date: Option<DateTime<Utc>>,
@@ -118,7 +118,7 @@ pub struct Generator {
 
 /// [Generator Engine](https://github.com/oasis-tcs/csaf/blob/master/csaf_2.0/prose/csaf-v2-editor-draft.md#321123-document-property---tracking---generator)
 #[serde_with::skip_serializing_none]
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct Engine {
     pub name: String,
     pub version: Option<String>,
@@ -140,7 +140,7 @@ impl std::default::Default for Generator {
 
 /// [Revision history](https://github.com/oasis-tcs/csaf/blob/master/csaf_2.0/prose/csaf-v2-editor-draft.md#321126-document-property---tracking---revision-history)
 #[serde_with::skip_serializing_none]
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct Revision {
     pub date: DateTime<Utc>,
     pub legacy_version: Option<String>,
@@ -149,7 +149,7 @@ pub struct Revision {
 }
 
 /// [Document status](https://github.com/oasis-tcs/csaf/blob/master/csaf_2.0/prose/csaf-v2-editor-draft.md#321127-document-property---tracking---status)
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[serde(rename_all = "lowercase")]
 pub enum Status {
     Draft,
@@ -159,7 +159,7 @@ pub enum Status {
 
 /// [Aggregate severity](https://github.com/oasis-tcs/csaf/blob/master/csaf_2.0/prose/csaf-v2-editor-draft.md#3212-document-property---aggregate-severity)
 #[serde_with::skip_serializing_none]
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct AggregateSeverity {
     pub text: String,
     pub namespace: Option<Url>,
@@ -167,7 +167,7 @@ pub struct AggregateSeverity {
 
 /// [Distribution](https://github.com/oasis-tcs/csaf/blob/master/csaf_2.0/prose/csaf-v2-editor-draft.md#3215-document-property---distribution)
 #[serde_with::skip_serializing_none]
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct Distribution {
     // TODO: enforce 'with at least 1 of the 2 properties'
     pub text: Option<String>,
@@ -176,14 +176,14 @@ pub struct Distribution {
 
 /// [TLP](https://github.com/oasis-tcs/csaf/blob/master/csaf_2.0/prose/csaf-v2-editor-draft.md#32152-document-property---distribution---tlp)
 #[serde_with::skip_serializing_none]
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct Tlp {
     pub label: TlpLabel,
     pub url: Option<Url>,
 }
 
 /// [TLP](https://github.com/oasis-tcs/csaf/blob/master/csaf_2.0/prose/csaf-v2-editor-draft.md#32152-document-property---distribution---tlp)
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub enum TlpLabel {
     AMBER,
     GREEN,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,7 @@ pub mod interop;
 ///
 /// Interoperatbility with [RustSec](https://rustsec.org/) advisories is provided by a `From` implementation.
 #[serde_with::skip_serializing_none]
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct Csaf {
     pub document: Document,
     pub product_tree: Option<ProductTree>,

--- a/src/product_tree.rs
+++ b/src/product_tree.rs
@@ -4,7 +4,7 @@ use crate::definitions::{BranchesT, FullProductName, ProductGroupIdT, ProductIdT
 
 /// [Product Tree](https://github.com/oasis-tcs/csaf/blob/master/csaf_2.0/prose/csaf-v2-editor-draft.md#322-product-tree-property)
 #[serde_with::skip_serializing_none]
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct ProductTree {
     pub branches: Option<BranchesT>,
     pub full_product_names: Option<Vec<FullProductName>>,
@@ -14,7 +14,7 @@ pub struct ProductTree {
 
 /// [Product Groups](https://github.com/oasis-tcs/csaf/blob/master/csaf_2.0/prose/csaf-v2-editor-draft.md#3223-product-tree-property---product-groups)
 #[serde_with::skip_serializing_none]
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct ProductGroup {
     pub group_id: ProductGroupIdT,
     pub product_ids: Vec<ProductIdT>,
@@ -22,7 +22,7 @@ pub struct ProductGroup {
 }
 
 /// [Relationships](https://github.com/oasis-tcs/csaf/blob/master/csaf_2.0/prose/csaf-v2-editor-draft.md#3224-product-tree-property---relationships)
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct Relationship {
     pub category: RelationshipCategory,
     pub full_product_name: FullProductName,
@@ -31,7 +31,7 @@ pub struct Relationship {
 }
 
 /// [Relationships](https://github.com/oasis-tcs/csaf/blob/master/csaf_2.0/prose/csaf-v2-editor-draft.md#3224-product-tree-property---relationships)
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub enum RelationshipCategory {
     DefaultComponentOf,

--- a/src/vulnerability.rs
+++ b/src/vulnerability.rs
@@ -8,7 +8,7 @@ use crate::definitions::{AcknowledgmentsT, NotesT, ProductGroupsT, ProductsT, Re
 /// [Vulnerabilities](https://github.com/oasis-tcs/csaf/blob/master/csaf_2.0/prose/csaf-v2-editor-draft.md#323-vulnerabilities-property)
 // TODO: At least one of these must be set
 #[serde_with::skip_serializing_none]
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct Vulnerability {
     pub acknowledgments: Option<AcknowledgmentsT>,
     pub cve: Option<String>,
@@ -28,7 +28,7 @@ pub struct Vulnerability {
 }
 
 /// [CWE](https://github.com/oasis-tcs/csaf/blob/master/csaf_2.0/prose/csaf-v2-editor-draft.md#3233-vulnerabilities-property---cwe)
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct Cwe {
     // TODO: Validation - The Weakness ID (id) has value type string with pattern (regular expression):
     pub id: String,
@@ -38,7 +38,7 @@ pub struct Cwe {
 
 /// [Flags](https://github.com/oasis-tcs/csaf/blob/master/csaf_2.0/prose/csaf-v2-editor-draft.md#3235-vulnerabilities-property---flags)
 #[serde_with::skip_serializing_none]
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct Flag {
     pub label: FlagLabel,
     pub date: Option<DateTime<Utc>>,
@@ -46,7 +46,7 @@ pub struct Flag {
     pub product_ids: Option<ProductsT>,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub enum FlagLabel {
     ComponentNotPresent,
@@ -57,7 +57,7 @@ pub enum FlagLabel {
 }
 
 /// [Vulnerability ID](https://github.com/oasis-tcs/csaf/blob/master/csaf_2.0/prose/csaf-v2-editor-draft.md#3235-vulnerabilities-property---id)
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct VulnerabilityId {
     pub system_name: String,
     pub text: String,
@@ -65,7 +65,7 @@ pub struct VulnerabilityId {
 
 /// [Involvements](https://github.com/oasis-tcs/csaf/blob/master/csaf_2.0/prose/csaf-v2-editor-draft.md#3236-vulnerabilities-property---involvements)
 #[serde_with::skip_serializing_none]
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct Involvement {
     pub party: InvolvementParty,
     pub status: InvolvementStatus,
@@ -74,7 +74,7 @@ pub struct Involvement {
 }
 
 /// [Involvements](https://github.com/oasis-tcs/csaf/blob/master/csaf_2.0/prose/csaf-v2-editor-draft.md#3236-vulnerabilities-property---involvements)
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[serde(rename_all = "lowercase")]
 pub enum InvolvementParty {
     Coordinator,
@@ -85,7 +85,7 @@ pub enum InvolvementParty {
 }
 
 /// [Involvements](https://github.com/oasis-tcs/csaf/blob/master/csaf_2.0/prose/csaf-v2-editor-draft.md#3236-vulnerabilities-property---involvements)
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub enum InvolvementStatus {
     Completed,
@@ -98,7 +98,7 @@ pub enum InvolvementStatus {
 
 /// [Product Status](https://github.com/oasis-tcs/csaf/blob/master/csaf_2.0/prose/csaf-v2-editor-draft.md#3238-vulnerabilities-property---product-status)
 #[serde_with::skip_serializing_none]
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct ProductStatus {
     pub first_affected: Option<ProductsT>,
     pub first_fixed: Option<ProductsT>,
@@ -112,7 +112,7 @@ pub struct ProductStatus {
 
 /// [Remediations](https://github.com/oasis-tcs/csaf/blob/master/csaf_2.0/prose/csaf-v2-editor-draft.md#32311-vulnerabilities-property---remediations)
 #[serde_with::skip_serializing_none]
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct Remediation {
     pub category: RemediationCategory,
     pub details: String,
@@ -125,7 +125,7 @@ pub struct Remediation {
 }
 
 /// [Remediation Category](https://github.com/oasis-tcs/csaf/blob/master/csaf_2.0/prose/csaf-v2-editor-draft.md#323111-vulnerabilities-property---remediations---category)
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub enum RemediationCategory {
     Mitigation,
@@ -137,14 +137,14 @@ pub enum RemediationCategory {
 
 /// [Restart Required](https://github.com/oasis-tcs/csaf/blob/master/csaf_2.0/prose/csaf-v2-editor-draft.md#323117-vulnerabilities-property---remediations---restart-required)
 #[serde_with::skip_serializing_none]
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct RestartRequired {
     pub category: RestartCategory,
     pub details: Option<String>,
 }
 
 /// [Restart Required](https://github.com/oasis-tcs/csaf/blob/master/csaf_2.0/prose/csaf-v2-editor-draft.md#323117-vulnerabilities-property---remediations---restart-required)
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub enum RestartCategory {
     Connected,
@@ -161,7 +161,7 @@ pub enum RestartCategory {
 /// [Score](https://github.com/oasis-tcs/csaf/blob/master/csaf_2.0/prose/csaf-v2-editor-draft.md#32312-vulnerabilities-property---scores)
 #[serde_as]
 #[serde_with::skip_serializing_none]
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct Score {
     pub products: ProductsT,
     // TODO: A CVSS v2 representation, or just document it as out of scope
@@ -231,7 +231,7 @@ mod cvss_json {
 
 /// [Threats](https://github.com/oasis-tcs/csaf/blob/master/csaf_2.0/prose/csaf-v2-editor-draft.md#32313-vulnerabilities-property---threats)
 #[serde_with::skip_serializing_none]
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct Threat {
     pub category: ThreatCategory,
     pub details: String,
@@ -241,7 +241,7 @@ pub struct Threat {
 }
 
 /// [Threats](https://github.com/oasis-tcs/csaf/blob/master/csaf_2.0/prose/csaf-v2-editor-draft.md#32313-vulnerabilities-property---threats)
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub enum ThreatCategory {
     ExploitStatus,


### PR DESCRIPTION
Address #15 in part by implementing `Clone` and `PartialEq`. `Eq` blocked on `packageurl`, whose primary type [only implements `PartialEq`](https://github.com/althonos/packageurl.rs/blob/eddaaedfe9541ac99367a5b17d8ba53edeaa8b52/src/purl.rs#L39-L42). Checking with them on `Eq` feasibility before cutting a release for this.