### PR TITLE
Purl name encoding fix

### DIFF
--- a/src/definitions.rs
+++ b/src/definitions.rs
@@ -86,7 +86,7 @@ pub struct FullProductName {
 #[serde_with::skip_serializing_none]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct ProductIdentificationHelper {
-    #[serde(with = "custom_cpe_format")]
+    #[serde(default, with = "custom_cpe_format")]
     pub cpe: Option<cpe::uri::OwnedUri>,
     pub hashes: Option<Vec<HashCollection>>,
     pub model_numbers: Option<Vec<String>>, // TODO: No empty strings, enforce unique
@@ -120,7 +120,8 @@ mod custom_cpe_format {
     where
         D: Deserializer<'de>,
     {
-        match Option::<String>::deserialize(deserializer)? {
+        let result = Option::<String>::deserialize(deserializer);
+        match result? {
             None => Ok(None),
             Some(s) => {
                 let x = OwnedUri::from_str(s.as_str()).map_err(serde::de::Error::custom)?;

--- a/src/definitions.rs
+++ b/src/definitions.rs
@@ -27,7 +27,7 @@ impl BranchesT {
         if self.0.is_empty() {
             None
         } else {
-            Some(self.0.iter().map(|x| x.try_into().unwrap()).collect())
+            Some(self.0.iter().flat_map(|x| x.try_into().ok()).collect())
         }
     }
 }

--- a/src/interop.rs
+++ b/src/interop.rs
@@ -1,3 +1,6 @@
+#![allow(clippy::unwrap_used)]
+#![allow(clippy::expect_used)]
+
 #[cfg(feature = "rustsec-interop")]
 pub mod rustsec {
     use std::convert::TryInto;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![deny(clippy::unwrap_used)]
+#![deny(clippy::expect_used)]
 //! Common Security Advisory Framework (CSAF)
 //!
 //! A lovingly hand-crafted implementation of [CSAF](https://www.oasis-open.org/committees/tc_home.php?wg_abbrev=csaf) for Rust. Currently,

--- a/src/vulnerability.rs
+++ b/src/vulnerability.rs
@@ -1,6 +1,6 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
-use serde_with::{serde_as, FromInto};
+use serde_with::{serde_as, TryFromInto};
 use url::Url;
 
 use crate::definitions::{AcknowledgmentsT, NotesT, ProductGroupsT, ProductsT, ReferencesT};
@@ -167,7 +167,7 @@ pub struct Score {
     // TODO: A CVSS v2 representation, or just document it as out of scope
     // TODO: Should have at least one of:
     pub cvss_v2: Option<serde_json::Value>,
-    #[serde_as(as = "Option<FromInto<cvss_json::Cvss3>>")]
+    #[serde_as(as = "Option<TryFromInto<cvss_json::Cvss3>>")]
     pub cvss_v3: Option<cvss::v3::Base>,
 }
 
@@ -213,10 +213,11 @@ mod cvss_json {
         }
     }
 
-    impl From<Cvss3> for cvss::v3::Base {
-        fn from(b: Cvss3) -> Self {
+    impl TryFrom<Cvss3> for cvss::v3::Base {
+        type Error = <cvss::v3::Base as FromStr>::Err;
+
+        fn try_from(b: Cvss3) -> Result<Self, Self::Error> {
             cvss::v3::Base::from_str(&b.vector_string)
-            .expect("You should not have been able to construct a cvss_json::Cvss3 except from a cvss::v3::Base which should always have a valid vector string")
         }
     }
 

--- a/tests/rhba-2023_0564.json
+++ b/tests/rhba-2023_0564.json
@@ -79,6 +79,17 @@
           {
             "branches": [
               {
+                "category": "product_version",
+                "name": "eap7-resteasy-0:3.15.8-1.Final_redhat_00001.1.el8eap.src",
+                "product": {
+                  "name": "eap7-resteasy-0:3.15.8-1.Final_redhat_00001.1.el8eap.src",
+                  "product_id": "eap7-resteasy-0:3.15.8-1.Final_redhat_00001.1.el8eap.src",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/eap7-resteasy@3.15.8-1.Final_redhat_00001.1.el8eap?arch=src"
+                  }
+                }
+              },
+              {
                 "category": "product_name",
                 "name": "Red Hat OpenShift Container Platform 4.11",
                 "product": {


### PR DESCRIPTION
Not sure if this is worth merging, but I wanted a branch to which I could refer trustify to fix https://github.com/guacsec/trustify/issues/2146 which required changes to https://github.com/scm-rs/packageurl.rs/pull/29 upon which this crate also depends, so I needed this one to depend on the same version as trustify does.

Note that the parent of this change is not main, but the specific revision trustify requires. Otherwise, various unrelated CVSS scoring tests failed.